### PR TITLE
fix: consolidate throw distance estimate

### DIFF
--- a/src/systems/throw/ThrowSystem.ts
+++ b/src/systems/throw/ThrowSystem.ts
@@ -223,9 +223,16 @@ export class ThrowSystem {
   isOvercharging(): boolean { return this.overchargeActive; }
 
   // ShotHud expects both:
-  estimateCarryFeet(v01: number): number {
-    const p = Number.isFinite(v01 as any) ? Phaser.Math.Clamp(v01, 0, 1) : 0;
-    const px = Number(this.computeCarryPx(p, false)) || 0;
+  // Estimate carry distance in feet. If no power value is provided the
+  // current meter value is used. Prior to this fix the method required an
+  // argument which led to a duplicate implementation later in the file to
+  // support calls without parameters. Making the parameter optional keeps the
+  // HUD API simple and removes the need for a second method.
+  estimateCarryFeet(v01?: number): number {
+    const m = Number.isFinite(v01 as any)
+      ? Phaser.Math.Clamp(v01 as number, 0, 1)
+      : Phaser.Math.Clamp(this.getMeter01(), 0, 1);
+    const px = Number(this.computeCarryPx(m, false)) || 0;
     return Math.max(0, this.pxToFeet(px * 0.6));   // conservative readout
   }
   getActiveDisc(): any {
@@ -347,25 +354,6 @@ export class ThrowSystem {
     const id = this.slot === 1 ? "dev_driver" : this.slot === 2 ? "dev_mid" : "dev_putt";
     return list.find(d => d.id === id) || { id, name:id, speed:7, glide:4, turn:-1, fade:2, slot:"driver" };
   }
-public estimateCarryFeet(meter01?: number){
-  try{
-    const t:any = (this as any).tuning?.flight ?? {};
-    const d:any = this.getActiveDisc?.() ?? { speed:5, glide:4, slot:"mid" };
-    const m = Phaser.Math.Clamp(meter01 ?? this.getMeter01?.() ?? 0, 0, 1);
-
-    const speed01 = this.map01(d.speed ?? 5, 1, 14);
-    const carryMult = this.lerp(t.speedToCarryMult?.min ?? 0.7, t.speedToCarryMult?.max ?? 1.3, speed01);
-
-    const baseBySlot = t.baseCarryFeetAtFull ?? { driver:350, mid:260, putter:190 };
-    const slot = (d.slot ?? "mid").toLowerCase();
-    const slotBase = baseBySlot[slot] ?? 260;
-
-    const glide01 = this.map01(d.glide ?? 4, 1, 7);
-    const dragMult = this.lerp(t.glideToDragMult?.min ?? 1.2, t.glideToDragMult?.max ?? 0.85, glide01);
-
-    return (slotBase * carryMult * m) * (1 / dragMult);
-  } catch(e){ return 0; }
-}
   private __initPowerBar(){
     const ui = (this as any).uiDepth ?? 2000;
     if (!this.__pbBG) this.__pbBG = this.scene.add.rectangle(24,78,220,12,0x000000,0.35).setOrigin(0,0).setDepth(ui);


### PR DESCRIPTION
## Summary
- make ThrowSystem.estimateCarryFeet accept optional power and default to current meter
- remove obsolete duplicate estimateCarryFeet implementation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bd9f7092c83319a8b92b6a874e718