### PR TITLE
Clarify meter self-update mechanism

### DIFF
--- a/drive-sync/src/systems/meters.ts.txt
+++ b/drive-sync/src/systems/meters.ts.txt
@@ -88,7 +88,7 @@ export function createMeters(scene: Phaser.Scene): Meters {
     }
   }
 
-  // Power animator (Scene.update should call meters.step(dt) but weâ€™ll self-update)
+  // Power animator (we'll self-update by subscribing to scene.events.on('update'))
   scene.events.on('update', (_t, dt:number)=>{
     if (powerActive) {
       power += POWER_CHARGE_RATE * dt * powerDir;

--- a/src/systems/meters.ts
+++ b/src/systems/meters.ts
@@ -88,7 +88,7 @@ export function createMeters(scene: Phaser.Scene): Meters {
     }
   }
 
-  // Power animator (Scene.update should call meters.step(dt) but weâ€™ll self-update)
+  // Power animator (we'll self-update by subscribing to scene.events.on('update'))
   scene.events.on('update', (_t, dt:number)=>{
     if (powerActive) {
       power += POWER_CHARGE_RATE * dt * powerDir;


### PR DESCRIPTION
## Summary
- Explain that the power meter self-updates by subscribing to `scene.events.on('update')`
- Replace misencoded text with correctly formatted "we'll"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bdcc53694833194a303e39ef8eb32